### PR TITLE
Add missing await statement to example & test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const server = new StreamingServer({
 
 const run = async () => {
 	try {
-		server.start();
+		await server.start();
 	} catch (e) {
 		console.error(e);
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ const server = new StreamingServer({
 
 const run = async () => {
 	try {
-		server.start();
+		await server.start();
 	} catch (e) {
 		console.error(e);
 	}


### PR DESCRIPTION
`catch` won't catch any errors from `server.start()` without awaiting.