### PR TITLE
Fix 'headers already sent' error

### DIFF
--- a/lib/ClientServer.js
+++ b/lib/ClientServer.js
@@ -22,7 +22,7 @@ class ClientServer {
 					return this.playRequest(req, res);
 				default:
 					console.log(req.method, req.url);
-					res.statusCode = 501 // Not implemented 
+					res.statusCode = 501; // Not implemented 
 					return res.end();
 			}
 		});
@@ -53,7 +53,7 @@ class ClientServer {
 
 		if(!mount){
 			res.statusCode = 404;
-			res.end();
+			return res.end();
 		}
 
 		res.setHeader('Content-Type', 'application/sdp');
@@ -68,7 +68,7 @@ class ClientServer {
 		//TCP not supported (yet ;-))
 		if(req.headers.transport.toLowerCase().indexOf('tcp') > -1){
 			res.statusCode = 504;
-			res.end();
+			return res.end();
 		}
 
 		let client = new Client(this.mounts, req);


### PR DESCRIPTION
In the error cases for DESCRIBE and SETUP, success logic is being executed after the response is sent with an error code.