### PR TITLE
As per RFC 2326 the status code for an unsupported transport is 461

### DIFF
--- a/src/lib/ClientServer.ts
+++ b/src/lib/ClientServer.ts
@@ -145,7 +145,7 @@ export class ClientServer {
 
     // TCP not supported (yet ;-))
     if (req.headers.transport && req.headers.transport.toLowerCase().indexOf('tcp') > -1) {
-      debug('%s:%s - we dont support tcp, sending 504: %o', req.socket.remoteAddress, req.socket.remotePort, req.uri);
+      debug('%s:%s - we dont support tcp, sending 461: %o', req.socket.remoteAddress, req.socket.remotePort, req.uri);
       res.statusCode = 461;
       return res.end();
     }

--- a/src/lib/ClientServer.ts
+++ b/src/lib/ClientServer.ts
@@ -41,7 +41,7 @@ export class ClientServer {
     };
 
     this.server = createServer((req: RtspRequest, res: RtspResponse) => {
-      debug('%s:%s request: %s', req.socket.remoteAddress, req.socket.remotePort, req.method);
+      debug('%s:%s request: %s %s', req.socket.remoteAddress, req.socket.remotePort, req.method, req.uri);
       switch (req.method) {
         case 'DESCRIBE':
           return this.describeRequest(req, res);
@@ -146,7 +146,7 @@ export class ClientServer {
     // TCP not supported (yet ;-))
     if (req.headers.transport && req.headers.transport.toLowerCase().indexOf('tcp') > -1) {
       debug('%s:%s - we dont support tcp, sending 504: %o', req.socket.remoteAddress, req.socket.remotePort, req.uri);
-      res.statusCode = 504;
+      res.statusCode = 461;
       return res.end();
     }
 


### PR DESCRIPTION
…https://www.rfc-editor.org/rfc/rfc2326.html#page-43)

This fixes an issue with VLC in iOS which seems to retry request when a 504 error is sent back.

@chriswiggins would love if you could take the time to publish this. If not I'll publish my own fork in a few weeks.