### PR TITLE
Add support for TCP interleaved clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2558,6 +2558,15 @@
           "dev": true,
           "optional": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2567,15 +2576,6 @@
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -4300,7 +4300,7 @@
       "integrity": "sha1-BuSymJSKA9g6XHFzMK/2aGiLGr8=",
       "requires": {
         "debug": "^2.2.0",
-        "rtsp-stream": "^1.0.0"
+        "rtsp-stream": "npm:@slyoldfox/rtsp-stream@1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -4315,32 +4315,17 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "rtsp-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rtsp-stream/-/rtsp-stream-1.0.0.tgz",
-      "integrity": "sha1-n+oNf4GGfB8nI7pU8W3PawUY55U=",
-      "requires": {
-        "debug": "^2.2.0",
-        "http-headers": "^1.2.0",
-        "next-line": "^1.1.0",
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        "rtsp-stream": {
+          "version": "npm:@slyoldfox/rtsp-stream@1.0.1",
+          "resolved": "https://registry.npmjs.org/@slyoldfox/rtsp-stream/-/rtsp-stream-1.0.1.tgz",
+          "integrity": "sha512-ca6QvY1+u9g3e4Fc4dhWlmqArE6YiHt2knlLGjGrcIppqy5u7iS09OftldIoEr6nG15zTLYpVTASw1hfrLzfsA==",
+          "requires": {
+            "debug": "^2.2.0",
+            "http-headers": "^1.2.0",
+            "next-line": "^1.1.0",
+            "readable-stream": "^2.0.2"
+          }
         }
       }
     },
@@ -4665,6 +4650,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -4680,14 +4673,6 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,10 @@
     "type": "git",
     "url": "https://github.com/chriswiggins/rtsp-streaming-server.git"
   },
+  "overrides": {
+    "rtsp-server": {
+      "rtsp-stream": "npm:@slyoldfox/rtsp-stream@1.0.1"
+    }
+  },
   "types": "build/index.d.ts"
 }

--- a/src/lib/Mount.ts
+++ b/src/lib/Mount.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 
-import { Client } from './Client';
+import { Client, InterleavedTcpClient } from './Client';
 import { Mounts } from './Mounts';
 import { PublishServerHooksConfig } from './PublishServer';
 import { RtpUdp } from './RtpUdp';
@@ -11,7 +11,7 @@ const debug = getDebugger('Mount');
 export type RtspStream = {
   id: number; // Not a UUID, this is the streamId in the RTSP spec
   mount: Mount;
-  clients: { [clientId: string]: Client };
+  clients: { [clientId: string]: Client|InterleavedTcpClient };
   listenerRtp?: RtpUdp;
   listenerRtcp?: RtpUdp;
   rtpStartPort: number;
@@ -135,7 +135,7 @@ export class Mount {
     return ports;
   }
 
-  clientLeave (client: Client) {
+  clientLeave (client: Client|InterleavedTcpClient) {
     delete this.streams[client.stream.id].clients[client.id];
     let empty: boolean = true;
     for (let stream in this.streams) {


### PR DESCRIPTION
Just polling how you feel about this PR. After my last commit, looked into TCP support and it seems like adding support for TCP/interleaved clients was reasonably straightforward.

This does depend on an open PR https://github.com/watson/rtsp-stream/pull/7 which filters interleaved packets from the rtsp-stream Decoder. A `TEARDOWN` request would error if the interleaved packets weren't filtered out for the Decoder.

The commit which fixes this (https://github.com/watson/rtsp-stream/pull/7/commits/7971c9942cc7f5b04f285d8125c495a0ba27e397) has been around since 2018, I just kicked off the PR to see if @watson merges it.

I have created a forked version 1.0.1 which incorporates that commit:
https://www.npmjs.com/package/@slyoldfox/rtsp-stream

This also explain the need for the `overrides` inside the package.json inside this PR.

The whole thing has been forked in a `2.1.0-interleaved` version at https://www.npmjs.com/package/@slyoldfox/rtsp-streaming-server?activeTab=versions in case the PRs don't come through.

Been testing this for a little while for my project (https://github.com/slyoldfox/c300x-controller) and it seems like interleaving successfully works through a NAT port-forwarding setup for my doorbell.