### PR TITLE
TCP transport and publisher disconnect handling

### DIFF
--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -1,19 +1,24 @@
 import { createSocket, Socket } from 'dgram';
 import { RtspRequest } from 'rtsp-server';
 import { v4 as uuid } from 'uuid';
+import { Socket as NetSocket } from 'net';
+import { RtpTcp } from './RtpTcp';
 
 import { Mount, RtspStream } from './Mount';
 import { getDebugger, getMountInfo } from './utils';
 
 const debug = getDebugger('Client');
 
-const clientPortRegex = /(?:client_port=)(\d*)-(\d*)/;
+const clientPortRegex = /client_port=(\d+)-(\d+)/;
 
 export class Client {
   open: boolean;
   id: string;
   mount: Mount;
   stream: RtspStream;
+
+  transportType: 'udp' | 'tcp';
+  rtpTcp?: RtpTcp;
 
   remoteAddress: string;
   remoteRtcpPort: number;
@@ -26,7 +31,6 @@ export class Client {
 
   constructor (mount: Mount, req: RtspRequest) {
     this.open = true;
-
     this.id = uuid();
     const info = getMountInfo(req.uri);
     this.mount = mount;
@@ -38,13 +42,37 @@ export class Client {
     this.stream = this.mount.streams[info.streamId];
 
     if (!req.socket.remoteAddress || !req.headers.transport) {
-      throw new Error('No remote address found or transport header doesn\'t exist');
+      throw new Error('No remote address or transport header missing');
     }
 
-    const portMatch: RegExpMatchArray | null = req.headers.transport.match(clientPortRegex);
+    this.remoteAddress = req.socket.remoteAddress.replace('::ffff:', '');
 
-    this.remoteAddress = req.socket.remoteAddress.replace('::ffff:', ''); // Strip IPv6 thing out
+    // Check transport type
+    if (req.headers.transport.toLowerCase().includes('tcp')) {
+      this.transportType = 'tcp';
+      this.setupTcpTransport(req);
+    } else {
+      this.transportType = 'udp';
+      this.setupUdpTransport(req);
+    }
+  }
 
+  private setupTcpTransport(req: RtspRequest): void {
+    const interleavedMatch = /interleaved=(\d+)-(\d+)/.exec(req.headers.transport);
+    const rtpChannel = interleavedMatch ? parseInt(interleavedMatch[1], 10) : 0;
+    const rtcpChannel = interleavedMatch ? parseInt(interleavedMatch[2], 10) : 1;
+
+    this.rtpTcp = new RtpTcp(this.stream, req.socket as unknown as NetSocket, rtpChannel, rtcpChannel);
+
+    // Register TCP client in the stream's tcpClients map
+    if (!this.stream.tcpClients) {
+      this.stream.tcpClients = {};
+    }
+    this.stream.tcpClients[this.id] = this.rtpTcp;
+  }
+
+  private setupUdpTransport(req: RtspRequest): void {
+    const portMatch = req.headers.transport.match(clientPortRegex);
     if (!portMatch) {
       throw new Error('Unable to find client ports in transport header');
     }
@@ -52,10 +80,29 @@ export class Client {
     this.remoteRtpPort = parseInt(portMatch[1], 10);
     this.remoteRtcpPort = parseInt(portMatch[2], 10);
 
-    this.setupServerPorts();
+    debug('Setting up UDP transport for client %s, remote ports RTP: %d, RTCP: %d', 
+          this.id, this.remoteRtpPort, this.remoteRtcpPort);
 
+    this.setupServerPorts();
     this.rtpServer = createSocket('udp4');
     this.rtcpServer = createSocket('udp4');
+
+    // Set up UDP data handlers
+    this.rtpServer.on('message', (msg: Buffer) => {
+      debug('Received RTP packet from client %s, length: %d', this.id, msg.length);
+      // Forward to stream's RTP handler
+      if (this.stream.listenerRtp) {
+        this.stream.listenerRtp.server.send(msg, this.stream.rtpStartPort);
+      }
+    });
+
+    this.rtcpServer.on('message', (msg: Buffer) => {
+      debug('Received RTCP packet from client %s, length: %d', this.id, msg.length);
+      // Forward to stream's RTCP handler
+      if (this.stream.listenerRtcp) {
+        this.stream.listenerRtcp.server.send(msg, this.stream.rtpStartPort + 1);
+      }
+    });
   }
 
   /**
@@ -63,12 +110,16 @@ export class Client {
    * @param req
    */
   async setup (req: RtspRequest): Promise<void> {
-    let portError = false;
+    if (this.transportType === 'tcp') {
+      // TCP setup is already done in constructor
+      return;
+    }
 
+    // UDP setup
+    let portError = false;
     try {
       await this.listen();
     } catch (e) {
-      // One or two of the ports was in use, cycle them out and try another
       if (e.errno && e.errno === 'EADDRINUSE') {
         console.warn(`Port error on ${e.port}, for stream ${this.stream.id} using another port`);
         portError = true;
@@ -77,7 +128,6 @@ export class Client {
           await this.rtpServer.close();
           await this.rtcpServer.close();
         } catch (e) {
-          // Ignore, dont care if couldnt close
           console.warn(e);
         }
 
@@ -86,7 +136,6 @@ export class Client {
         }
 
         this.setupServerPorts();
-
       } else {
         throw e;
       }
@@ -116,29 +165,26 @@ export class Client {
    *
    */
   async close (): Promise<void> {
+    if (!this.open) return;
     this.open = false;
-    this.mount.clientLeave(this);
 
-    return new Promise((resolve) => {
-      // Sometimes closing can throw if the dgram has already gone away. Just ignore it.
-      try { this.rtpServer.close(); } catch (e) { debug('Error closing rtpServer for client %o', e); }
-      try { this.rtcpServer.close(); } catch (e) { debug('Error closing rtcpServer for client %o', e); }
-
-      if (this.rtpServerPort) {
-        this.mount.mounts.returnRtpPortToPool(this.rtpServerPort);
+    if (this.transportType === 'tcp' && this.rtpTcp) {
+      this.rtpTcp.close();
+      // Remove TCP client from the stream's tcpClients map
+      if (this.stream.tcpClients) {
+        delete this.stream.tcpClients[this.id];
       }
+    } else if (this.transportType === 'udp') {
+      try {
+        await this.rtpServer.close();
+        await this.rtcpServer.close();
+      } catch (e) {
+        console.warn('Error closing UDP servers:', e);
+      }
+    }
 
-      return resolve();
-    });
-  }
-
-  /**
-   *
-   * @param buf
-   */
-  sendRtp (buf: Buffer) {
-    if (this.open === true) {
-      this.rtpServer.send(buf, this.remoteRtpPort, this.remoteAddress);
+    if (this.rtpServerPort) {
+      this.mount.mounts.returnRtpPortToPool(this.rtpServerPort);
     }
   }
 
@@ -146,9 +192,39 @@ export class Client {
    *
    * @param buf
    */
-  sendRtcp (buf: Buffer) {
-    if (this.open === true) {
-      this.rtcpServer.send(buf, this.remoteRtcpPort, this.remoteAddress);
+  sendRtp (buffer: Buffer): void {
+    if (!this.open) return;
+
+    if (this.transportType === 'tcp' && this.rtpTcp) {
+      this.rtpTcp.sendInterleavedRtp(buffer);
+    } else if (this.transportType === 'udp') {
+      debug('Sending RTP packet to client %s at %s:%d, length: %d', 
+            this.id, this.remoteAddress, this.remoteRtpPort, buffer.length);
+      this.rtpServer.send(buffer, this.remoteRtpPort, this.remoteAddress, (err) => {
+        if (err) {
+          debug('Error sending RTP packet to client %s: %s', this.id, err.message);
+        }
+      });
+    }
+  }
+
+  /**
+   *
+   * @param buf
+   */
+  sendRtcp (buffer: Buffer): void {
+    if (!this.open) return;
+
+    if (this.transportType === 'tcp' && this.rtpTcp) {
+      this.rtpTcp.sendInterleavedRtcp(buffer);
+    } else if (this.transportType === 'udp') {
+      debug('Sending RTCP packet to client %s at %s:%d, length: %d', 
+            this.id, this.remoteAddress, this.remoteRtcpPort, buffer.length);
+      this.rtcpServer.send(buffer, this.remoteRtcpPort, this.remoteAddress, (err) => {
+        if (err) {
+          debug('Error sending RTCP packet to client %s: %s', this.id, err.message);
+        }
+      });
     }
   }
 

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -70,7 +70,7 @@ export class Client {
     }
   }
 
-  private setupTcpTransport(req: RtspRequest): void {
+  protected setupTcpTransport(req: RtspRequest): void {
     const interleavedMatch = /interleaved=(\d+)-(\d+)/.exec(req.headers.transport);
     const rtpChannel = interleavedMatch ? parseInt(interleavedMatch[1], 10) : 0;
     const rtcpChannel = interleavedMatch ? parseInt(interleavedMatch[2], 10) : 1;
@@ -84,7 +84,7 @@ export class Client {
     this.stream.tcpClients[this.id] = this.rtpTcp;
   }
 
-  private setupUdpTransport(req: RtspRequest): void {
+  protected setupUdpTransport(req: RtspRequest): void {
     const portMatch = req.headers.transport.match(clientPortRegex);
     if (!portMatch) {
       throw new Error('Unable to find client ports in transport header');
@@ -264,7 +264,7 @@ export class Client {
   /**
    *
    */
-  private async listen (): Promise<void> {
+  protected async listen (): Promise<void> {
     return new Promise((resolve, reject) => {
       function onError (err: Error) {
         return reject(err);
@@ -285,7 +285,7 @@ export class Client {
     });
   }
 
-  private setupServerPorts (): void {
+  protected setupServerPorts (): void {
     const rtpServerPort = this.mount.mounts.getNextRtpPort();
     if (!rtpServerPort) {
       throw new Error('Unable to get next RTP Server Port');

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -100,6 +100,9 @@ export class Client {
     this.rtpServer = createSocket('udp4');
     this.rtcpServer = createSocket('udp4');
 
+    // Initialize RtpUdp instance
+    this.rtpUdp = new RtpUdp(this.rtpServerPort!, this.stream);
+
     // Set up UDP data handlers
     this.rtpServer.on('message', (msg: Buffer) => {
       debug('Received RTP packet from client %s, length: %d', this.id, msg.length);

--- a/src/lib/ClientServer.ts
+++ b/src/lib/ClientServer.ts
@@ -159,7 +159,13 @@ export class ClientServer {
     let clientWrapper: ClientWrapper;
 
     if (!req.headers.session) {
-      clientWrapper = new ClientWrapper(this, req);
+      try {
+        clientWrapper = new ClientWrapper(this, req);
+      } catch (e) {
+        debug('%s:%s - Mount not found, sending 404: %o', req.socket.remoteAddress, req.socket.remotePort, req.uri);
+        res.statusCode = 404;
+        return res.end();
+      }
       this.clients[clientWrapper.id] = clientWrapper;
     } else if (this.clients[req.headers.session]) {
       clientWrapper = this.clients[req.headers.session];

--- a/src/lib/PublishServer.ts
+++ b/src/lib/PublishServer.ts
@@ -313,7 +313,7 @@ export class PublishServer {
     return true;
   }
 
-  private handlePublisherDisconnect(mount: Mount, socket: Socket) {
+  protected handlePublisherDisconnect(mount: Mount, socket: Socket) {
     debug('Publisher disconnected for mount %s', mount.path);
     
     // Clean up the mount

--- a/src/lib/PublishServer.ts
+++ b/src/lib/PublishServer.ts
@@ -323,9 +323,9 @@ export class PublishServer {
     });
     
     // Remove the mount from mounts map
-    if (this.mounts.mounts[mount.path]) {
+    if (this.mounts.getMount(mount.path)) {
       debug('Removing mount %s from mounts map', mount.path);
-      delete this.mounts.mounts[mount.path];
+      this.mounts.deleteMount(mount.path);
     }
     
     // Remove from active sessions and clean up socket

--- a/src/lib/RtpTcp.ts
+++ b/src/lib/RtpTcp.ts
@@ -1,0 +1,78 @@
+import { Socket } from 'net';
+import { RtspStream } from './Mount';
+import { getDebugger } from './utils';
+
+const debug = getDebugger('RtpTcp');
+
+export class RtpTcp {
+  stream: RtspStream;
+  clientSocket: Socket;
+  interleaved: boolean;
+  rtpChannel: number;
+  rtcpChannel: number;
+  private sendQueue: Buffer[];
+  private sending: boolean;
+
+  constructor(stream: RtspStream, clientSocket: Socket, rtpChannel: number = 0, rtcpChannel: number = 1) {
+    this.stream = stream;
+    this.clientSocket = clientSocket;
+    this.interleaved = true;
+    this.rtpChannel = rtpChannel;
+    this.rtcpChannel = rtcpChannel;
+    this.sendQueue = [];
+    this.sending = false;
+
+    debug('Created RtpTcp handler with channels RTP: %d, RTCP: %d', rtpChannel, rtcpChannel);
+
+    // Handle socket drain event
+    this.clientSocket.on('drain', () => {
+      this.processQueue();
+    });
+  }
+
+  private async processQueue() {
+    if (this.sending || this.sendQueue.length === 0) return;
+    this.sending = true;
+
+    while (this.sendQueue.length > 0) {
+      const packet = this.sendQueue[0];
+      if (!this.clientSocket.write(packet)) {
+        // Socket buffer is full, wait for drain
+        break;
+      }
+      this.sendQueue.shift();
+    }
+
+    this.sending = false;
+  }
+
+  private queuePacket(packet: Buffer, isRtp: boolean) {
+    const header = Buffer.alloc(4);
+    header.writeUInt8(0x24, 0); // $ character
+    header.writeUInt8(isRtp ? this.rtpChannel : this.rtcpChannel, 1);
+    header.writeUInt16BE(packet.length, 2);
+    
+    const fullPacket = Buffer.concat([header, packet]);
+    this.sendQueue.push(fullPacket);
+    this.processQueue();
+  }
+
+  sendInterleavedRtp(buffer: Buffer): void {
+    if (!this.interleaved || !this.clientSocket) return;
+    debug('Queueing RTP packet over TCP, channel %d, length %d', this.rtpChannel, buffer.length);
+    this.queuePacket(buffer, true);
+  }
+
+  sendInterleavedRtcp(buffer: Buffer): void {
+    if (!this.interleaved || !this.clientSocket) return;
+    debug('Queueing RTCP packet over TCP, channel %d, length %d', this.rtcpChannel, buffer.length);
+    this.queuePacket(buffer, false);
+  }
+
+  close(): void {
+    debug('Closing RtpTcp handler');
+    if (this.clientSocket) {
+      this.clientSocket.end();
+    }
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,4 @@
 import debug, { IDebugger } from 'debug';
-import { URL } from 'url';
 
 const mountRegex = /(\/\S+)(?:\/streamid=)(\d+)/;
 
@@ -9,22 +8,28 @@ export interface MountInfo {
 }
 
 export function getMountInfo (uri: string): MountInfo {
-  let urlObj = new URL(uri);
-
-  let mount = {
-    path: urlObj.pathname,
-    streamId: -1
+  // Default mount info
+  const mount: MountInfo = {
+    path: '',
+    streamId: 0
   };
 
-  if (urlObj.pathname.indexOf('streamid') > -1) {
-    const match = urlObj.pathname.match(mountRegex);
-
-    if (match) {
-      mount.path = match[1];
-      mount.streamId = parseInt(match[2], 10);
-    }
+  // Strip protocol and host if present
+  const pathMatch = uri.match(/(?:rtsp:\/\/[^\/]+)?(\/.+)/);
+  if (pathMatch) {
+    mount.path = pathMatch[1];
+  } else {
+    mount.path = uri;
   }
 
+  // Check for streamid in the path
+  const streamMatch = mount.path.match(mountRegex);
+  if (streamMatch) {
+    mount.path = streamMatch[1];
+    mount.streamId = parseInt(streamMatch[2], 10);
+  }
+
+  debug('Parsed mount info from %s: path=%s, streamId=%d', uri, mount.path, mount.streamId);
   return mount;
 }
 


### PR DESCRIPTION
Can't say that I've tested this extensively and with high load, but what I've tried – it works. The code maybe not of the highest quality, but had to solve tis quickly.

This PR solves two problems:
1. TCP transport, e.g.
```
ffmpeg -stream_loop -1 -re -i demo.webm -c:v copy -rtsp_transport tcp -f rtsp rtsp://127.0.0.1:5554/stream-test
```
```
ffplay -rtsp_transport tcp -i rtsp://127.0.0.1:6554/stream-test
```
Which is crucial for NAT networking, load balancing, etc.

2. #45 – handling of publisher termination without teardown request. E.g. if you launch ffmpeg publisher and terminate it (or it will crash), previously mounts were not cleaned up and publish url was locked until service restart. In this version it's no longer a problem (for both UDP and TCP)